### PR TITLE
Fix ordering of constructors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Suggests:
     sf,
     testthat (>= 3.0.0),
     wk
-Config/rextendr/version: 0.3.1.9000
+Config/rextendr/version: 0.3.1.9001
 SystemRequirements: Cargo (Rust's package manager), rustc
 Config/testthat/edition: 3
 Config/Needs/website: rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# unreleased
+# rsgeo 0.1.6.9000 unreleased
+
+* Bug fix: `line_segmentize()` would not always return `n` elements (h/t [@Robinlovelace](https://github.com/Robinlovelace))
+* `geom_linestring()`, `geom_polygon()` and `geom_multipoint()` constructors ignored order. This was due to the internal use of a `HashMap`. These have been swapped to a `BTreeMap` which preserves order. Additional tests have been added to compare to`sf`s constructors as validation.
 
 # rsgeo 0.1.6
 

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -35,8 +35,8 @@ geom_polygon <- function(x, y, id = 1, ring = 1) {
   geom_polygon_(
     as.double(x),
     as.double(y),
-    as.integer(id),
-    as.integer(ring)
+    as.integer(ring),
+    as.integer(id)
   )
 }
 

--- a/src/rust/src/construction.rs
+++ b/src/rust/src/construction.rs
@@ -1,7 +1,7 @@
 use extendr_api::prelude::*;
 use geo_types::{coord, point, Coord, LineString, MultiPoint, Point, Polygon};
 use sfconversions::{vctrs::geom_class, Geom};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub trait IsReal {
     fn is_real(&self) -> bool;
@@ -57,7 +57,7 @@ fn geom_multipoint_(x: Doubles, y: Doubles, id: Integers) -> Robj {
     };
 
     // create empty hash map to store unique vectors of points
-    let mut map_mpnts: HashMap<i32, Vec<Point>> = HashMap::new();
+    let mut map_mpnts: BTreeMap<i32, Vec<Point>> = BTreeMap::new();
 
     // iterate through everything and create points
     for ((xi, yi), idx) in x.iter().zip(y.iter()).zip(id.iter()) {
@@ -100,7 +100,7 @@ fn geom_linestring_(x: Doubles, y: Doubles, id: Integers) -> Robj {
     };
 
     // create empty hash map to store unique vectors of points
-    let mut map_mpnts: HashMap<i32, Vec<Coord>> = HashMap::new();
+    let mut map_mpnts: BTreeMap<i32, Vec<Coord>> = BTreeMap::new();
 
     // iterate through everything and create points
     for ((xi, yi), idx) in x.iter().zip(y.iter()).zip(id.iter()) {
@@ -152,7 +152,7 @@ fn geom_polygon_(x: Doubles, y: Doubles, id: Integers, ring: Integers) -> Robj {
     };
 
     // create empty hash map to store unique vectors of points for each ring
-    let mut map_rings: HashMap<i32, HashMap<i32, Vec<Coord>>> = HashMap::new();
+    let mut map_rings: BTreeMap<i32, BTreeMap<i32, Vec<Coord>>> = BTreeMap::new();
 
     // iterate through everything and create points
     for (((xi, yi), idx), ring_idx) in x.iter().zip(y.iter()).zip(id.iter()).zip(ring.iter()) {
@@ -162,7 +162,7 @@ fn geom_polygon_(x: Doubles, y: Doubles, id: Integers, ring: Integers) -> Robj {
 
             map_rings
                 .entry(ring_idx.inner())
-                .or_insert(HashMap::new())
+                .or_insert(BTreeMap::new())
                 .entry(idx.inner())
                 .or_insert(Vec::new())
                 .push(pnt);

--- a/tests/testthat/test-geometry-construction.R
+++ b/tests/testthat/test-geometry-construction.R
@@ -1,0 +1,32 @@
+test_that("LineStrings are constructed in order", {
+  skip_if_not_installed("sf")
+  skip_on_cran()
+
+  x <- 1:10
+  y <- 10:1
+  id <- x
+  line <- geom_linestring(x, y, id)
+
+  crds <- sf::st_coordinates(sf::st_as_sfc(line))
+
+  expect_equal(x, crds[, "X"])
+  expect_equal(y, crds[, "Y"])
+  expect_equal(id, crds[, "L1"])
+})
+
+
+test_that("Polygons are constructed in order", {
+  m <- matrix(c(0, 1, 1, 0, 0, 0, 0, 1, 1, 0), ncol = 2)
+  m2 <- m - 0.5
+  all_m <- cbind(rbind(m, m2), rep(1:2, each = 5))
+
+  rs_ply <- geom_polygon(all_m[,1], all_m[,2], all_m[,3])
+
+  sf_plys <- sf::st_sfc(
+    sf::st_polygon(list(m)),
+    sf::st_polygon(list(m2))
+  )
+
+  expect_equal(sf::st_as_sfc(rs_ply), sf_plys, ignore_attr = TRUE)
+})
+

--- a/tests/testthat/test-geometry-construction.R
+++ b/tests/testthat/test-geometry-construction.R
@@ -16,6 +16,9 @@ test_that("LineStrings are constructed in order", {
 
 
 test_that("Polygons are constructed in order", {
+  skip_if_not_installed("sf")
+  skip_on_cran()
+
   m <- matrix(c(0, 1, 1, 0, 0, 0, 0, 1, 1, 0), ncol = 2)
   m2 <- m - 0.5
   all_m <- cbind(rbind(m, m2), rep(1:2, each = 5))


### PR DESCRIPTION
Closes https://github.com/JosiahParry/rsgeo/issues/27

`geom_linestring()`, `geom_polygon()` and `geom_multipoint()` constructors ignored order. This was due to the internal use of a `HashMap`. These have been swapped to a `BTreeMap` which preserves order. Additional tests have been added to compare to`sf`s constructors as validation.
